### PR TITLE
API Router implement with version prefix

### DIFF
--- a/accounting/authentication/routing.py
+++ b/accounting/authentication/routing.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException
+from utils.api_versioning import APIRouter, APIVersion
 from . import endpoints
 from .jwt import oauth2_scheme
 from .schemas import (
@@ -12,6 +12,7 @@ auth_router = APIRouter(
         404: {"description": "URL not found"},
         400: {"description": "Bad request"}
         },
+    version=APIVersion(1)
 )
 
 auth_router.add_api_route(

--- a/accounting/groups/routing.py
+++ b/accounting/groups/routing.py
@@ -1,4 +1,5 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import Depends
+from utils.api_versioning import APIRouter, APIVersion
 from .endpoints import GroupCRUD
 from accounting.schemas import (
    GroupRead
@@ -12,7 +13,8 @@ group_router = APIRouter(
         404: {"description": "URL not found"},
         400: {"description": "Bad request"}
         },
-    dependencies=[Depends(get_user_by_token)]
+    dependencies=[Depends(get_user_by_token)],
+    version=APIVersion(1)
 )
 
 group_router.add_api_route(

--- a/accounting/rbac/routing.py
+++ b/accounting/rbac/routing.py
@@ -1,4 +1,5 @@
-from fastapi import APIRouter, Depends
+from fastapi import Depends
+from utils.api_versioning import APIRouter, APIVersion
 from .endpoints import (
     UserRoleCRUD, 
     UserGroupCRUD, 
@@ -21,7 +22,8 @@ rbac_user_router = APIRouter(
         404: {"description": "URL not found"},
         400: {"description": "Bad request"}
         },
-    dependencies=[Depends(get_user_by_token)]
+    dependencies=[Depends(get_user_by_token)],
+    version=APIVersion(1)
 )
 
 rbac_role_router = APIRouter(
@@ -31,7 +33,8 @@ rbac_role_router = APIRouter(
         404: {"description": "URL not found"},
         400: {"description": "Bad request"}
         },
-    dependencies=[Depends(get_user_by_token)]
+    dependencies=[Depends(get_user_by_token)],
+    version=APIVersion(1)
 )
 
 rbac_group_router = APIRouter(
@@ -41,7 +44,8 @@ rbac_group_router = APIRouter(
         404: {"description": "URL not found"},
         400: {"description": "Bad request"}
         },
-    dependencies=[Depends(get_user_by_token)]
+    dependencies=[Depends(get_user_by_token)],
+    version=APIVersion(1)
 )
 
 rbac_permissions_router = APIRouter(
@@ -51,7 +55,8 @@ rbac_permissions_router = APIRouter(
         404: {"description": "URL not found"},
         400: {"description": "Bad request"}
         },
-    dependencies=[Depends(get_user_by_token)]
+    dependencies=[Depends(get_user_by_token)],
+    version=APIVersion(1)
 )
 
 rbac_policies_router = APIRouter(
@@ -61,7 +66,8 @@ rbac_policies_router = APIRouter(
         404: {"description": "URL not found"},
         400: {"description": "Bad request"}
         },
-    dependencies=[Depends(get_user_by_token)]
+    dependencies=[Depends(get_user_by_token)],
+    version=APIVersion(1)
 )
 
 rbac_user_router.add_api_route(

--- a/accounting/roles/routing.py
+++ b/accounting/roles/routing.py
@@ -1,4 +1,5 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import Depends
+from utils.api_versioning import APIRouter, APIVersion
 from .endpoints import RoleCRUD
 from accounting.schemas import (
    RoleRead,
@@ -12,7 +13,8 @@ role_router = APIRouter(
         404: {"description": "URL not found"},
         400: {"description": "Bad request"}
         },
-    dependencies=[Depends(get_user_by_token)]
+    dependencies=[Depends(get_user_by_token)],
+    version=APIVersion(1)
 )
 
 role_router.add_api_route(

--- a/accounting/users/routing.py
+++ b/accounting/users/routing.py
@@ -1,10 +1,10 @@
-from fastapi import APIRouter, Depends
+from fastapi import Depends
 from .endpoints import UserCRUD
 from accounting.schemas import (
    UserRead,
 )
 from accounting.authentication.jwt import get_user_by_token
-
+from utils.api_versioning import APIRouter, APIVersion
 user_router = APIRouter(
     prefix="/accounting/users",
     tags=["AAA->Accounting->Users"],
@@ -12,7 +12,8 @@ user_router = APIRouter(
         404: {"description": "URL not found"},
         400: {"description": "Bad request"}
         },
-    dependencies=[Depends(get_user_by_token)]
+    dependencies=[Depends(get_user_by_token)],
+    version=APIVersion(1)
 )
 
 user_router.add_api_route(

--- a/utils/api_versioning.py
+++ b/utils/api_versioning.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter as _APIRouter
+from typing import NamedTuple
+
+class APIVersion(NamedTuple):
+
+    major: int = 1
+    minor: int | None = None
+
+    def __str__(self)->str:
+        if self.minor is not None:
+            return f"{self.major}_{self.minor}"
+        else:
+            return f"{self.major}"
+
+class APIRouter(_APIRouter):
+    def __init__(self, version: APIVersion | None=None, **kwargs):
+        super().__init__(**kwargs)
+        if version:
+            self.prefix = f"/v{version}{self.prefix}"


### PR DESCRIPTION
Closes #24 
Inherited APIRouter from standart FastAPI APIRouter

Usage:
```python
from utils.api_versioning import APIRouter, APIVersion
user_router = APIRouter(
    prefix="/accounting/users",
    tags=["AAA->Accounting->Users"],
    responses={
        404: {"description": "URL not found"},
        400: {"description": "Bad request"}
        },
    dependencies=[Depends(get_user_by_token)],
    version=APIVersion(1,2)
)
```